### PR TITLE
[Feat]ユーザー登録の際にメール認証をできるようにする

### DIFF
--- a/app/src/main/java/com/example/funcy_portfolio_android/model/AuthData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/AuthData.kt
@@ -1,0 +1,10 @@
+package com.example.funcy_portfolio_android.model
+
+data class AuthData(
+    val code: String,
+    val userID: String
+)
+
+data class UserIdData(
+    val userID : String,
+)

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/ICreationApi.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/ICreationApi.kt
@@ -1,6 +1,7 @@
 package com.example.funcy_portfolio_android.model
 
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.*
 
 
@@ -22,5 +23,5 @@ interface ICreationApi {
     suspend fun sendUserRegistration(
         @Header("token") token: String,
         @Body signupData : SignupData
-    ): SignupData
+    ): Response<SignupData>
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/ICreationApi.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/ICreationApi.kt
@@ -21,7 +21,11 @@ interface ICreationApi {
     //登録データ送信
     @POST("sign/up")
     suspend fun sendUserRegistration(
-        @Header("token") token: String,
-        @Body signupData : SignupData
-    ): Response<SignupData>
+        @Body signupData : SignupData,
+    ): Response<UserIdData>
+
+    @POST("auth/code")
+    suspend fun sendAuthCode(
+        @Body authData: AuthData
+    ): Response<Void>
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/Repository.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/Repository.kt
@@ -9,7 +9,7 @@ import java.io.IOException
 
 class Repository{
     /* （本物のサーバができるまで）自分のPCのローカルipアドレスにする */
-    val URL = "http://10.124.57.64:8080/"
+    val URL = "http://192.168.3.17:9000/"
 
     val gson = GsonBuilder()
         .serializeNulls()

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/Service.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/Service.kt
@@ -4,7 +4,7 @@ import com.google.gson.GsonBuilder
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-val URL = "http://10.124.58.211:8080/"
+val URL = "http://192.168.3.17:9000/"
 
 val gson = GsonBuilder()
     .serializeNulls()

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/SignupData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/SignupData.kt
@@ -1,7 +1,7 @@
 package com.example.funcy_portfolio_android.model
 
 data class SignupData(
-    val FamilyName: String,
+    val familyName: String,
     val course: String,
     val displayName: String,
     val firstName: String,

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/SharedPref.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/SharedPref.kt
@@ -7,7 +7,7 @@ enum class Keys {
     USERID,
 }
 
-class UserIdSavePref(
+class SharedPref(
     private val context: Context
 ) {
 
@@ -17,7 +17,7 @@ class UserIdSavePref(
 
     private lateinit var sharedPreferences: SharedPreferences
 
-    fun savePrefUserId(key: String, value: String){
+    fun saveSharedPrefString(key: String, value: String){
         sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
         val prefEditor = sharedPreferences.edit().apply {
             putString(key, value)
@@ -25,7 +25,7 @@ class UserIdSavePref(
         }
     }
 
-    fun readPrefUserId(key: String) : String? {
+    fun readSharedPref(key: String) : String? {
         val defValue: String? = null
         sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
         return sharedPreferences.getString(key, defValue)

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
@@ -13,17 +13,17 @@ class UserIdSavePref(
 
     private lateinit var sharedPreferences: SharedPreferences
 
-    fun savePrefUserId(userId: String){
+    fun savePrefUserId(key: String, value: String){
         sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
         val prefEditor = sharedPreferences.edit().apply {
-            putString("userId", userId)
+            putString(key, value)
             apply()
         }
     }
 
-    fun readPrefUserId() : String? {
+    fun readPrefUserId(key: String) : String? {
         val defValue: String? = null
         sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
-        return sharedPreferences.getString("userId", defValue)
+        return sharedPreferences.getString(key, defValue)
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
@@ -1,0 +1,29 @@
+package com.example.funcy_portfolio_android.model.localDataSource
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class UserIdSavePref(
+    private val context: Context
+) {
+
+    companion object{
+        const val KEY_USER_DATA = "funcy_user_setting"
+    }
+
+    private lateinit var sharedPreferences: SharedPreferences
+
+    fun savePrefUserId(userId: String){
+        sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
+        val prefEditor = sharedPreferences.edit().apply {
+            putString("userId", userId)
+            apply()
+        }
+    }
+
+    fun readPrefUserId() : String? {
+        val defValue: String? = null
+        sharedPreferences = context.getSharedPreferences(KEY_USER_DATA, Context.MODE_PRIVATE)
+        return sharedPreferences.getString("userId", defValue)
+    }
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/localDataSource/UserIdSavePref.kt
@@ -3,6 +3,10 @@ package com.example.funcy_portfolio_android.model.localDataSource
 import android.content.Context
 import android.content.SharedPreferences
 
+enum class Keys {
+    USERID,
+}
+
 class UserIdSavePref(
     private val context: Context
 ) {

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentAuthenticationBinding
 import com.example.funcy_portfolio_android.model.localDataSource.Keys
-import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
+import com.example.funcy_portfolio_android.model.localDataSource.SharedPref
 
 enum class AuthApiStatus{ INIT, LOADING, SUCCESS, FAILURE}
 
@@ -33,7 +33,7 @@ class AuthenticationFragment: Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val userIdPref = UserIdSavePref(requireActivity())
+        val sharedPref = SharedPref(requireActivity())
 
         viewModel.authStatus.observe(viewLifecycleOwner) { status ->
             when (status) {
@@ -48,7 +48,7 @@ class AuthenticationFragment: Fragment() {
         }
 
         binding.buttonUserID.setOnClickListener {
-            val userId = userIdPref.readPrefUserId(Keys.USERID.name)
+            val userId = sharedPref.readSharedPref(Keys.USERID.name)
             if (userId != null) {
                 viewModel.sendAuthCode(userId)
             }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -1,6 +1,8 @@
 package com.example.funcy_portfolio_android.ui.authentication
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -38,16 +40,33 @@ class AuthenticationFragment: Fragment() {
         viewModel.authStatus.observe(viewLifecycleOwner) { status ->
             when (status) {
                 AuthApiStatus.SUCCESS -> {
-                    findNavController().navigate(R.id.action_authenticationFragment_to_MainFragment)
+                    viewModel.text.value = getString(R.string.comp_registration_message)
+                    binding.buttonSendAuthCode.visibility = View.GONE
+                    binding.textNotReceive.visibility = View.GONE
+                    binding.inputDisplayName.visibility = View.GONE
+
+                    Handler(Looper.getMainLooper()).postDelayed(
+                        {
+                            findNavController().navigate(R.id.action_authenticationFragment_to_MainFragment)
+                        }
+                        ,2000
+                    )
                 }
                 AuthApiStatus.FAILURE -> {
                     Toast.makeText(context, "コードが間違っています", Toast.LENGTH_LONG).show()
                 }
                 AuthApiStatus.LOADING -> {}
+                AuthApiStatus.INIT -> {
+                    viewModel.text.value = getString(R.string.message_send_mail)
+                    binding.buttonSendAuthCode.visibility = View.VISIBLE
+                    binding.textNotReceive.visibility = View.VISIBLE
+                    binding.inputDisplayName.visibility = View.VISIBLE
+                }
+                else -> {}
             }
         }
 
-        binding.buttonUserID.setOnClickListener {
+        binding.buttonSendAuthCode.setOnClickListener {
             val userId = sharedPref.readSharedPref(Keys.USERID.name)
             if (userId != null) {
                 viewModel.sendAuthCode(userId)

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -1,0 +1,28 @@
+package com.example.funcy_portfolio_android.ui.authentication
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import com.example.funcy_portfolio_android.R
+import com.example.funcy_portfolio_android.databinding.FragmentAuthenticationBinding
+
+class AuthenticationFragment: Fragment() {
+    private lateinit var binding: FragmentAuthenticationBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_authentication, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -4,13 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentAuthenticationBinding
+import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
 
 class AuthenticationFragment: Fragment() {
     private lateinit var binding: FragmentAuthenticationBinding
+    private val viewModel: AuthenticationViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -18,11 +22,18 @@ class AuthenticationFragment: Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_authentication, container, false)
+        binding.viewModel = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val userIdPref = UserIdSavePref(requireActivity())
+
+        binding.buttonUserID.setOnClickListener {
+            val userId = userIdPref.readPrefUserId()
+            Toast.makeText(context, userId, Toast.LENGTH_LONG).show()
+        }
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -8,13 +8,18 @@ import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentAuthenticationBinding
 import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
 
+enum class AuthApiStatus{ INIT, LOADING, SUCCESS, FAILURE}
+
 class AuthenticationFragment: Fragment() {
     private lateinit var binding: FragmentAuthenticationBinding
     private val viewModel: AuthenticationViewModel by viewModels()
+
+    private val USER_ID = "userID"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,12 +36,23 @@ class AuthenticationFragment: Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val userIdPref = UserIdSavePref(requireActivity())
 
+        viewModel.authStatus.observe(viewLifecycleOwner) { status ->
+            when (status) {
+                AuthApiStatus.SUCCESS -> {
+                    findNavController().navigate(R.id.action_authenticationFragment_to_MainFragment)
+                }
+                AuthApiStatus.FAILURE -> {
+                    Toast.makeText(context, "コードが間違っています", Toast.LENGTH_LONG).show()
+                }
+                AuthApiStatus.LOADING -> {}
+            }
+        }
+
         binding.buttonUserID.setOnClickListener {
-            val userId = userIdPref.readPrefUserId()
+            val userId = userIdPref.readPrefUserId(USER_ID)
             if (userId != null) {
                 viewModel.sendAuthCode(userId)
             }
-            Toast.makeText(context, userId, Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -33,6 +33,9 @@ class AuthenticationFragment: Fragment() {
 
         binding.buttonUserID.setOnClickListener {
             val userId = userIdPref.readPrefUserId()
+            if (userId != null) {
+                viewModel.sendAuthCode(userId)
+            }
             Toast.makeText(context, userId, Toast.LENGTH_LONG).show()
         }
     }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentAuthenticationBinding
+import com.example.funcy_portfolio_android.model.localDataSource.Keys
 import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
 
 enum class AuthApiStatus{ INIT, LOADING, SUCCESS, FAILURE}
@@ -18,8 +19,6 @@ enum class AuthApiStatus{ INIT, LOADING, SUCCESS, FAILURE}
 class AuthenticationFragment: Fragment() {
     private lateinit var binding: FragmentAuthenticationBinding
     private val viewModel: AuthenticationViewModel by viewModels()
-
-    private val USER_ID = "userID"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -49,7 +48,7 @@ class AuthenticationFragment: Fragment() {
         }
 
         binding.buttonUserID.setOnClickListener {
-            val userId = userIdPref.readPrefUserId(USER_ID)
+            val userId = userIdPref.readPrefUserId(Keys.USERID.name)
             if (userId != null) {
                 viewModel.sendAuthCode(userId)
             }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -1,10 +1,26 @@
 package com.example.funcy_portfolio_android.ui.authentication
 
-import androidx.lifecycle.LiveData
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.funcy_portfolio_android.model.AuthData
+import com.example.funcy_portfolio_android.model.apiService
+import kotlinx.coroutines.launch
 
 class AuthenticationViewModel: ViewModel() {
-    private var _inputCode = MutableLiveData<String>()
-    val inputCode: LiveData<String> = _inputCode
+    val inputCode = MutableLiveData<String>()
+
+    fun sendAuthCode(userId: String){
+        viewModelScope.launch {
+            try {
+                apiService.service.sendAuthCode(
+                    AuthData(inputCode.value!!, userId)
+                )
+                Log.d("Authentication", "ok")
+            }catch (e: Exception){
+                Log.d("Authentication", "エラー$e")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -1,0 +1,10 @@
+package com.example.funcy_portfolio_android.ui.authentication
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class AuthenticationViewModel: ViewModel() {
+    private var _inputCode = MutableLiveData<String>()
+    val inputCode: LiveData<String> = _inputCode
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
 class AuthenticationViewModel: ViewModel() {
-    val inputCode = MutableLiveData<String>()
+    val inputCode = MutableLiveData<String>("")
 
     private val _authStatus = MutableLiveData<AuthApiStatus>(AuthApiStatus.INIT)
     val authStatus: LiveData<AuthApiStatus> = _authStatus

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -16,6 +16,8 @@ class AuthenticationViewModel: ViewModel() {
     private val _authStatus = MutableLiveData<AuthApiStatus>(AuthApiStatus.INIT)
     val authStatus: LiveData<AuthApiStatus> = _authStatus
 
+    val text = MutableLiveData<String>("")
+
     fun sendAuthCode(userId: String){
         viewModelScope.launch {
             try{
@@ -23,7 +25,7 @@ class AuthenticationViewModel: ViewModel() {
                     AuthData(inputCode.value!!, userId)
                 )
                 if(response.isSuccessful){
-                    Log.i("Authentication", "認証が完了しました${response.message()}")
+                    Log.i("Authentication", "認証が完了しました${response.body()}")
                     _authStatus.value = AuthApiStatus.SUCCESS
 
                 }else {

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.funcy_portfolio_android.ui.authentication
 
 import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,15 +12,21 @@ import kotlinx.coroutines.launch
 class AuthenticationViewModel: ViewModel() {
     val inputCode = MutableLiveData<String>()
 
+    private val _authStatus = MutableLiveData<AuthApiStatus>(AuthApiStatus.INIT)
+    val authStatus: LiveData<AuthApiStatus> = _authStatus
+
     fun sendAuthCode(userId: String){
         viewModelScope.launch {
-            try {
-                apiService.service.sendAuthCode(
-                    AuthData(inputCode.value!!, userId)
-                )
-                Log.d("Authentication", "ok")
-            }catch (e: Exception){
-                Log.d("Authentication", "エラー$e")
+            val response = apiService.service.sendAuthCode(
+                AuthData(inputCode.value!!, userId)
+            )
+            if(response.isSuccessful){
+                Log.d("Authentication", "認証が完了しました")
+                _authStatus.value = AuthApiStatus.SUCCESS
+
+            }else {
+                Log.d("Authentication", "認証エラー$response")
+                _authStatus.value = AuthApiStatus.FAILURE
             }
         }
     }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.funcy_portfolio_android.model.AuthData
 import com.example.funcy_portfolio_android.model.apiService
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 
 class AuthenticationViewModel: ViewModel() {
     val inputCode = MutableLiveData<String>()
@@ -17,15 +18,24 @@ class AuthenticationViewModel: ViewModel() {
 
     fun sendAuthCode(userId: String){
         viewModelScope.launch {
-            val response = apiService.service.sendAuthCode(
-                AuthData(inputCode.value!!, userId)
-            )
-            if(response.isSuccessful){
-                Log.d("Authentication", "認証が完了しました")
-                _authStatus.value = AuthApiStatus.SUCCESS
+            try{
+                val response = apiService.service.sendAuthCode(
+                    AuthData(inputCode.value!!, userId)
+                )
+                if(response.isSuccessful){
+                    Log.i("Authentication", "認証が完了しました${response.message()}")
+                    _authStatus.value = AuthApiStatus.SUCCESS
 
-            }else {
-                Log.d("Authentication", "認証エラー$response")
+                }else {
+                    Log.i("Authentication", "認証エラー${response.message()}")
+                    _authStatus.value = AuthApiStatus.FAILURE
+                }
+            }catch (e: HttpException){
+                Log.i("Authentication", "通信エラー$e")
+                _authStatus.value = AuthApiStatus.FAILURE
+
+            }catch (e: Throwable){
+                Log.i("Authentication", "エラー$e")
                 _authStatus.value = AuthApiStatus.FAILURE
             }
         }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -104,6 +104,8 @@ class SignupFragment : Fragment() {
                     binding.buttonSignup.visibility = View.VISIBLE
                     Toast.makeText(context,"エラー", Toast.LENGTH_SHORT).show()
                 }
+                SignupApiStatus.INIT -> {}
+                else -> {}
             }
         })
     }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -20,7 +20,7 @@ import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentSignupBinding
 import com.example.funcy_portfolio_android.model.localDataSource.Keys
-import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
+import com.example.funcy_portfolio_android.model.localDataSource.SharedPref
 
 
 class SignupFragment : Fragment() {
@@ -75,7 +75,7 @@ class SignupFragment : Fragment() {
         })
 
         viewModel.signupStatus.observe(viewLifecycleOwner, Observer { status ->
-            val userIdPref = UserIdSavePref(requireActivity())
+            val sharedPref = SharedPref(requireActivity())
             when(status){
                 SignupApiStatus.LOADING -> {
                     binding.imageDone.visibility = View.GONE
@@ -92,7 +92,7 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            userIdPref.savePrefUserId(Keys.USERID.name, viewModel.userId.value.toString())
+                            sharedPref.saveSharedPrefString(Keys.USERID.name, viewModel.userId.value.toString())
                             findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
                         }
                         ,2000

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -27,6 +27,8 @@ class SignupFragment : Fragment() {
     private lateinit var binding: FragmentSignupBinding
     private val viewModel by viewModels<SignupViewModel>()
 
+    private val USER_ID = "userID"
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -91,7 +93,7 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            userIdPref.savePrefUserId(viewModel.userId.value.toString())
+                            userIdPref.savePrefUserId(USER_ID, viewModel.userId.value.toString())
                             findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
                         }
                         ,2000

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -83,7 +83,7 @@ class SignupFragment : Fragment() {
                     binding.progressDialog.visibility = View.VISIBLE
                     binding.buttonSignup.visibility = View.GONE
                 }
-                SignupApiStatus.DONE -> {
+                SignupApiStatus.SUCCESS -> {
                     binding.textDialog.text = resources.getString(R.string.comp_registration_message)
                     binding.progressBar.visibility = View.GONE
                     binding.imageDone.visibility = View.VISIBLE
@@ -98,11 +98,11 @@ class SignupFragment : Fragment() {
                         ,2000
                     )
                 }
-                SignupApiStatus.ERROR -> {
+                SignupApiStatus.FAILURE -> {
                     binding.background.visibility = View.GONE
                     binding.progressDialog.visibility = View.GONE
                     binding.buttonSignup.visibility = View.VISIBLE
-                    Toast.makeText(context,"通信エラー", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context,"エラー", Toast.LENGTH_SHORT).show()
                 }
             }
         })

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -91,7 +91,7 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            userIdPref.savePrefUserId("userIDです")
+                            userIdPref.savePrefUserId(viewModel.userId.value.toString())
                             findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
                         }
                         ,2000

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentSignupBinding
+import com.example.funcy_portfolio_android.model.localDataSource.Keys
 import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
 
 
@@ -26,8 +27,6 @@ class SignupFragment : Fragment() {
 
     private lateinit var binding: FragmentSignupBinding
     private val viewModel by viewModels<SignupViewModel>()
-
-    private val USER_ID = "userID"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -93,7 +92,7 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            userIdPref.savePrefUserId(USER_ID, viewModel.userId.value.toString())
+                            userIdPref.savePrefUserId(Keys.USERID.name, viewModel.userId.value.toString())
                             findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
                         }
                         ,2000

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentSignupBinding
+import com.example.funcy_portfolio_android.model.localDataSource.UserIdSavePref
 
 
 class SignupFragment : Fragment() {
@@ -40,6 +41,7 @@ class SignupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
 
         binding.buttonSignup.setOnClickListener {
             val grade = binding.spinnerGrade.selectedItem.toString()
@@ -72,6 +74,7 @@ class SignupFragment : Fragment() {
         })
 
         viewModel.signupStatus.observe(viewLifecycleOwner, Observer { status ->
+            val userIdPref = UserIdSavePref(requireActivity())
             when(status){
                 SignupApiStatus.LOADING -> {
                     binding.imageDone.visibility = View.GONE
@@ -88,7 +91,8 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            findNavController().navigate(R.id.action_SignupFragment_to_MainFragment)
+                            userIdPref.savePrefUserId("userIDです")
+                            findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
                         }
                         ,2000
                     )

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
@@ -12,7 +12,7 @@ import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.launch
 
 
-enum class SignupApiStatus{LOADING, ERROR, DONE}
+enum class SignupApiStatus{ LOADING, ERROR, DONE, INIT }
 
 class SignupViewModel: ViewModel() {
     val selectedItem = MutableLiveData<Int>()
@@ -32,7 +32,7 @@ class SignupViewModel: ViewModel() {
 
     private val checkMailPattern = Regex("^(b|g)([0-9]{7})")
 
-    private val _signupStatus = MutableLiveData<SignupApiStatus>()
+    private val _signupStatus = MutableLiveData<SignupApiStatus>(SignupApiStatus.INIT)
     val signupStatus: LiveData<SignupApiStatus> = _signupStatus
 
     fun setCourseId(){
@@ -54,11 +54,11 @@ class SignupViewModel: ViewModel() {
         _signupStatus.value = SignupApiStatus.LOADING
         viewModelScope.launch {
             try {
-                apiService.service.sendUserRegistration(
+                val data = apiService.service.sendUserRegistration(
                     token,
-                    SignupData(familyName.value!!, course, displayName.value!!, firstName.value!!, grade, "noIcon",sendMailAddress,password.value!!)
+                    SignupData(familyName.value!!, course, displayName.value!!, firstName.value!!, grade, "noIcon", sendMailAddress, password.value!!)
                 )
-                Log.d("SignUp", "送信成功")
+                Log.d("SignUp", "送信成功 : ${data}")
                 _signupStatus.value = SignupApiStatus.DONE
             }catch (e: Exception){
                 Log.d("SignUp", "エラー$e")

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
@@ -10,6 +10,7 @@ import com.example.funcy_portfolio_android.model.SignupData
 import com.example.funcy_portfolio_android.model.apiService
 import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 
 
 enum class SignupApiStatus{ LOADING, ERROR, DONE, INIT }
@@ -62,7 +63,7 @@ class SignupViewModel: ViewModel() {
                 ).body()?.userID
                 Log.d("SignUp", "送信成功 : ${_userId.value}")
                 _signupStatus.value = SignupApiStatus.DONE
-            }catch (e: Exception){
+            }catch (e: HttpException){
                 Log.d("SignUp", "エラー$e")
                 _signupStatus.value = SignupApiStatus.ERROR
             }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
@@ -23,6 +23,9 @@ class SignupViewModel: ViewModel() {
     private var _courseResource = MutableLiveData<Array<String>>()
     val courseResource: LiveData<Array<String>> = _courseResource
 
+    private var _userId = MutableLiveData<String>("userId")
+    val userId: LiveData<String> = _userId
+
     val displayName = MutableLiveData<String>()
     val familyName = MutableLiveData<String>()
     val firstName = MutableLiveData<String>()
@@ -54,11 +57,10 @@ class SignupViewModel: ViewModel() {
         _signupStatus.value = SignupApiStatus.LOADING
         viewModelScope.launch {
             try {
-                val data = apiService.service.sendUserRegistration(
-                    token,
+                _userId.value = apiService.service.sendUserRegistration(
                     SignupData(familyName.value!!, course, displayName.value!!, firstName.value!!, grade, "noIcon", sendMailAddress, password.value!!)
-                )
-                Log.d("SignUp", "送信成功 : ${data}")
+                ).body()?.userID
+                Log.d("SignUp", "送信成功 : ${_userId.value}")
                 _signupStatus.value = SignupApiStatus.DONE
             }catch (e: Exception){
                 Log.d("SignUp", "エラー$e")

--- a/app/src/main/res/drawable/ic_mail_outline.xml
+++ b/app/src/main/res/drawable/ic_mail_outline.xml
@@ -1,0 +1,5 @@
+<vector android:height="32dp" android:tint="#FF90B3"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8l8,5 8,-5v10zM12,11L4,6h16l-8,5z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -88,7 +88,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
-                    android:inputType="number" />
+                    android:inputType="number"
+                    android:text="@={viewModel.inputCode}"/>
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/topConstraint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageButton
+                android:id="@+id/btBack"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="@null"
+                android:contentDescription="@string/toolbar_back"
+                android:src="@drawable/bt_back"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:paddingHorizontal="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/topConstraint">
+
+            <TextView
+                android:id="@+id/text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:text="キーを入力してください"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/inputDisplayName"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:paddingVertical="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editDisplayName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:text="" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -67,11 +67,11 @@
                 app:layout_constraintTop_toBottomOf="@id/text">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/editDisplayName"
+                    android:id="@+id/inputCode"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
-                    android:text="" />
+                    android:text="@={viewModel.inputCode}" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.funcy_portfolio_android.ui.authentication.AuthenticationViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -68,6 +75,15 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <Button
+                android:id="@+id/buttonUserID"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="7dp"
+                android:text="UERIDREAD"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/inputDisplayName" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -50,7 +50,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="16dp"
-                android:text="キーを入力してください"
+                android:text="認証コードを入力してください"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -71,6 +71,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
+                    android:inputType="number"
                     android:text="@={viewModel.inputCode}" />
 
             </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -45,22 +45,39 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/topConstraint">
 
+            <ImageView
+                android:id="@+id/imageMail"
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                android:layout_marginTop="48dp"
+                android:scaleType="fitXY"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.498"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_mail_outline" />
+
             <TextView
                 android:id="@+id/text"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="16dp"
-                android:text="認証コードを入力してください"
+                android:layout_marginTop="24dp"
+                android:gravity="center"
+                android:text="@string/message_send_mail"
+                android:textSize="18sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toBottomOf="@id/imageMail" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/inputDisplayName"
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
                 android:ems="10"
+                android:hint="@string/input_code"
                 android:paddingVertical="4dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -71,20 +88,29 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
-                    android:inputType="number"
-                    android:text="@={viewModel.inputCode}" />
+                    android:inputType="number" />
 
             </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:id="@+id/textNotReceive"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/message_not_receive"
+                app:layout_constraintEnd_toEndOf="@+id/inputDisplayName"
+                app:layout_constraintStart_toStartOf="@+id/inputDisplayName"
+                app:layout_constraintTop_toBottomOf="@id/inputDisplayName" />
 
             <Button
                 android:id="@+id/buttonUserID"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="7dp"
-                android:text="UERIDREAD"
+                android:layout_marginTop="24dp"
+                android:text="@string/button_send_code"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/inputDisplayName" />
+                app:layout_constraintTop_toBottomOf="@+id/textNotReceive" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -24,10 +24,9 @@
         android:name="com.example.funcy_portfolio_android.ui.signup.SignupFragment"
         android:label="Signup Fragment"
         tools:layout="@layout/fragment_signup">
-
         <action
-            android:id="@+id/action_SignupFragment_to_MainFragment"
-            app:destination="@id/MainFragment" />
+            android:id="@+id/action_SignupFragment_to_authenticationFragment"
+            app:destination="@id/authenticationFragment" />
     </fragment>
 
     <fragment
@@ -116,6 +115,14 @@
         android:name="com.example.funcy_portfolio_android.ui.groupMypage.GroupMypageFragment"
         android:label="GroupMypageFragment"
         tools:layout="@layout/fragment_group_mypage"/>
+    <fragment
+        android:id="@+id/authenticationFragment"
+        android:name="com.example.funcy_portfolio_android.ui.authentication.AuthenticationFragment"
+        android:label="AuthenticationFragment" >
+        <action
+            android:id="@+id/action_authenticationFragment_to_MainFragment"
+            app:destination="@id/MainFragment" />
+    </fragment>
 
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,4 +154,10 @@
 
     <!---Signup Fragment-->
     <string name="comp_registration_message">登録が完了しました</string>
+
+    <!---Authentication Fragment-->
+    <string name="message_send_mail">入力したメールアドレスに\n確認コードを送信しました</string>
+    <string name="input_code">確認コードを入力してください</string>
+    <string name="button_send_code">送信</string>
+    <string name="message_not_receive">確認コードが届かない場合</string>
 </resources>


### PR DESCRIPTION
## 対応するissue
- close #82 

## 概要
- ユーザー登録の際にメール認証をできるようにする
- ユーザー登録情報をポスト後，レスポンスからuserIDを獲得，userIDとともにメールに送信されてきた認証コードをポスト

## 意図する動作内容（または変更点）
- ユーザ登録したあとに認証コード入力画面を表示
- 正しいコードを入力した場合は，メイン画面に遷移
- 間違ったコードを入力した場合は，トーストを表示し，間違っていることを伝える．

## スクリーンショット（UI作成，変更時）
<img src="https://user-images.githubusercontent.com/60728861/211386152-e884f742-f381-40ab-ab1d-e427a8eb1d7f.jpg" width="250"/>
