### PR TITLE
[Fix] Android Studio Flamingoでビルドできない問題の修正

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation "androidx.browser:browser:1.4.0"
     implementation 'com.google.android:flexbox:1.1.0'
     implementation 'com.github.bumptech.glide:glide:4.4.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
+    kapt 'com.github.bumptech.glide:compiler:4.4.0'
 
     // http通信
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 03 17:18:05 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 対応するissue
- close #{issue番号}

## 概要
- ビルド時にkaptのエラーが出ていた問題の修正

### 修正箇所
- JDKのバージョンを11から17に変更
- Kotlinのバージョンを1.5.31から1.8.10に変更
- Gradleのバージョンを7.4から7.6.1に変更
- annotationProcessorをkaptに置き換え

## 意図する動作内容（または変更点）
- Android Studio Flamingo, Electric Eel の両方でビルドできること
    - Electric Eel 以前のバージョンではJDK17をダウンロードするよう注が出ると思います。ダウンロード後ビルドできるか確認して欲しいです

## スクリーンショット（UI作成，変更時）
<img src="" width="300" />

## その他