### PR TITLE
[Fix] データクラスの変数名とJSONキー名の統一

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "androidx.browser:browser:1.4.0"
+    implementation 'androidx.browser:browser:1.4.0'
     implementation 'com.google.android:flexbox:1.1.0'
     implementation 'com.github.bumptech.glide:glide:4.4.0'
     kapt 'com.github.bumptech.glide:compiler:4.4.0'
@@ -57,7 +57,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.google.code.gson:gson:2.9.0'
-    implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 
     // coroutine
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
@@ -70,9 +70,9 @@ dependencies {
 
     implementation 'com.github.bumptech.glide:glide:4.13.0'
 
-    implementation "com.squareup.moshi:moshi-kotlin:1.12.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.12.0"
+    implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
+    kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.12.0'
 
     //coil
-    implementation "io.coil-kt:coil:1.1.1"
+    implementation 'io.coil-kt:coil:1.1.1'
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/AuthData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/AuthData.kt
@@ -1,8 +1,8 @@
 package com.example.funcy_portfolio_android.model.data
 
 data class AuthData(
-    val code: String,
-    val userID: String
+    val userID: String,
+    val code: String
 )
 
 data class UserIdData(

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/MyPageData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/MyPageData.kt
@@ -1,5 +1,9 @@
 package com.example.funcy_portfolio_android.model.data
 
+/**
+ * マイページ (mypage) のデータクラス
+ * @param works: 中身はWorkDataList.ktを参照してください
+ */
 data class MyPageData(
     val icon: String,
     val header: String,
@@ -8,5 +12,5 @@ data class MyPageData(
     val group: List<String>,
     val skills: List<String>,
     val displayName: String,
-    val works: List<WorkDataList>
+    val works: WorkDataList
 )

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/MyPageData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/MyPageData.kt
@@ -1,0 +1,12 @@
+package com.example.funcy_portfolio_android.model.data
+
+data class MyPageData(
+    val icon: String,
+    val header: String,
+    val user_description: String,
+    val sns: List<String>,
+    val group: List<String>,
+    val skills: List<String>,
+    val displayName: String,
+    val works: List<WorkDataList>
+)

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/SignupData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/SignupData.kt
@@ -1,5 +1,8 @@
 package com.example.funcy_portfolio_android.model.data
 
+/**
+ * サインアップ（ユーザ情報登録） (signup) のデータクラス
+ */
 data class SignupData(
     val icon: String,
     val familyName: String,

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/SignupData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/SignupData.kt
@@ -1,12 +1,12 @@
 package com.example.funcy_portfolio_android.model.data
 
 data class SignupData(
-    val familyName: String,
-    val course: String,
-    val displayName: String,
-    val firstName: String,
-    val grade: String,
     val icon: String,
+    val familyName: String,
+    val firstName: String,
     val mail: String,
-    val password: String
+    val password: String,
+    val grade: String,
+    val course: String,
+    val displayName: String
 )

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
@@ -1,7 +1,9 @@
 package com.example.funcy_portfolio_android.model.data
 
 data class WorkDataList(
-    val work_id: Int,
+    val workID: Int,
     val title: String,
-    val images: String
+    val thumbnail: String,
+    val description: String,
+    val icon: String,
 )

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
@@ -1,7 +1,12 @@
 package com.example.funcy_portfolio_android.model.data
 
+/**
+ * 作品一覧画面(main)のデータクラス
+ */
 data class WorkDataList(
-    val workID: Int,
+    val workID: String,
+    val userID: String,
+    val user_name: String,
     val title: String,
     val thumbnail: String,
     val description: String,

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
@@ -3,7 +3,11 @@ package com.example.funcy_portfolio_android.model.data
 /**
  * 作品一覧画面(main)のデータクラス
  */
+
 data class WorkDataList(
+    val works: List<WorkData>
+)
+data class WorkData(
     val workID: String,
     val userID: String,
     val user_name: String,

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDataList.kt
@@ -1,7 +1,7 @@
 package com.example.funcy_portfolio_android.model.data
 
 /**
- * 作品一覧画面(main)のデータクラス
+ * 作品一覧画面 (main) のデータクラス
  */
 
 data class WorkDataList(

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
@@ -6,11 +6,12 @@ data class WorkDetails(
     val thumbnail: String,
     val user_icon: String,
     val user_name: String,
+    val userID: String,
     val images: List<ImageData>,
     val work_url: String,
     val movie_url: String,
     val tags: List<TagData>,
-    val groupID: String?,
+    val group: String?,
     val security: Int,
 )
 

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
@@ -1,20 +1,23 @@
 package com.example.funcy_portfolio_android.model.data
 
-data class WorkData(
+data class WorkDetails(
     val title: String,
     val description: String,
+    val thumbnail: String,
+    val user_icon: String,
+    val user_name: String,
     val images: List<ImageData>,
-    val URL: String,
+    val work_url: String,
     val movie_url: String,
     val tags: List<TagData>,
-    val group: String?,
+    val groupID: String?,
     val security: Int,
 )
 
 data class ImageData(
-    val Image: String
+    val image: String
 )
 
 data class TagData(
-    val Tag: String
+    val tag: String
 )

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkDetails.kt
@@ -1,5 +1,8 @@
 package com.example.funcy_portfolio_android.model.data
 
+/**
+ * 作品詳細 (workDetail) のデータクラス
+ */
 data class WorkDetails(
     val title: String,
     val description: String,

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/repository/WorkRepository.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/repository/WorkRepository.kt
@@ -1,6 +1,6 @@
 package com.example.funcy_portfolio_android.model.repository
 
-import com.example.funcy_portfolio_android.model.data.WorkData
+import com.example.funcy_portfolio_android.model.data.WorkDetails
 import com.example.funcy_portfolio_android.network.ApiService
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
@@ -9,7 +9,7 @@ import java.io.IOException
 class WorkRepository() {
     private val service = ApiService.service
 
-    suspend fun registerWork(work: WorkData): String? {
+    suspend fun registerWork(work: WorkDetails): String? {
         val data = work
         var res = ""
 
@@ -26,7 +26,8 @@ class WorkRepository() {
         return res
     }
 
-    suspend fun getWorkDetail(token: String, workId:String) = service.getWorkDetail(token = token, workId =  workId)
+    suspend fun getWorkDetail(token: String, workId: String) =
+        service.getWorkDetail(token = token, workId = workId)
 
     suspend fun getWork(token: String) = service.getWorks(token = token)
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/network/FuncyApi.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/network/FuncyApi.kt
@@ -3,8 +3,8 @@ package com.example.funcy_portfolio_android.network
 import com.example.funcy_portfolio_android.model.data.AuthData
 import com.example.funcy_portfolio_android.model.data.SignupData
 import com.example.funcy_portfolio_android.model.data.UserIdData
-import com.example.funcy_portfolio_android.model.data.WorkData
 import com.example.funcy_portfolio_android.model.data.WorkDataList
+import com.example.funcy_portfolio_android.model.data.WorkDetails
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.*
@@ -14,14 +14,14 @@ interface FuncyApi {
     /* 作品の投稿（個人） */
     @Headers("token:Token1")
     @POST("work")
-    fun registerWorkData(@Body work: WorkData): Call<WorkData>
+    fun registerWorkData(@Body work: WorkDetails): Call<WorkDetails>
 
     //作品詳細取得
     @GET("work/{workID}")
     suspend fun getWorkDetail(
         @Header("token") token: String,
         @Path("workID") workId: String
-    ): WorkData
+    ): WorkDetails
 
     //登録データ送信
     @POST("sign/up")

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/authentication/AuthenticationViewModel.kt
@@ -24,7 +24,7 @@ class AuthenticationViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val response = userRepository.userAuthentication(
-                    AuthData(inputCode.value!!, userId)
+                    AuthData(userId, inputCode.value!!)
                 )
                 if (response.isSuccessful) {
                     Log.i("Authentication", "認証が完了しました${response.body()}")

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/CardAdapterBefore.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/CardAdapterBefore.kt
@@ -22,7 +22,7 @@ class CardAdapterBefore (private val worklist: List<WorkDataList>) : RecyclerVie
 
     override fun onBindViewHolder(viewHolder: CardAdapterBefore.ViewHolder, position: Int) {
         val work = worklist[position]
-        viewHolder.image.setImageResource(work.work_id)
+        viewHolder.image.setImageResource(work.workID)
         viewHolder.title.text = work.title
     }
     override fun getItemCount() = worklist.size

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/main/CardAdapter.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/main/CardAdapter.kt
@@ -8,23 +8,23 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.funcy_portfolio_android.databinding.CreateCardBinding
 import com.example.funcy_portfolio_android.model.data.WorkDataList
 
-class CardAdapter:ListAdapter<WorkDataList, CardAdapter.WorkDataViewHolder>(DiffCallBack){
+class CardAdapter : ListAdapter<WorkDataList, CardAdapter.WorkDataViewHolder>(DiffCallBack) {
 
-    class WorkDataViewHolder(private var binding: CreateCardBinding):
-            RecyclerView.ViewHolder(binding.root){
-                fun bind(workDataList: WorkDataList){
-                    binding.work = workDataList
-                    binding.executePendingBindings()
-                }
-            }
+    class WorkDataViewHolder(private var binding: CreateCardBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(workDataList: WorkDataList) {
+            binding.work = workDataList
+            binding.executePendingBindings()
+        }
+    }
 
-    companion object DiffCallBack : DiffUtil.ItemCallback<WorkDataList>(){
+    companion object DiffCallBack : DiffUtil.ItemCallback<WorkDataList>() {
         override fun areItemsTheSame(oldItem: WorkDataList, newItem: WorkDataList): Boolean {
-            return oldItem.work_id == newItem.work_id
+            return oldItem.workID == newItem.workID
         }
 
         override fun areContentsTheSame(oldItem: WorkDataList, newItem: WorkDataList): Boolean {
-            return oldItem.images == newItem.images
+            return oldItem.thumbnail == newItem.thumbnail
         }
 
     }
@@ -43,9 +43,6 @@ class CardAdapter:ListAdapter<WorkDataList, CardAdapter.WorkDataViewHolder>(Diff
         holder.bind(workData)
     }
 }
-
-
-
 
 
 //@BindingAdapter

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/main/MainViewModel.kt
@@ -1,10 +1,14 @@
 package com.example.funcy_portfolio_android.ui.main
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.funcy_portfolio_android.model.data.WorkDataList
 import com.example.funcy_portfolio_android.model.repository.WorkRepository
+import com.example.funcy_portfolio_android.ui.workRegister.WorkRegisterBottomSheet.Companion.TAG
+import kotlinx.coroutines.launch
 
 /*FUNCYサーバーとの接続を確認するステータスを定義*/
 enum class FuncyApiStatus { LOADING, ERROR, DONE }
@@ -21,24 +25,24 @@ class MainViewModel : ViewModel() {
     private val _status = MutableLiveData<FuncyApiStatus>()
     val status: LiveData<FuncyApiStatus> = _status
 
-//    init {
-//        getWorks("Token1")
-//    }
+    init {
+        getWorks("Token1")
+    }
 
-//    private fun getWorks(token: String) {
-//        viewModelScope.launch {
-//            _status.value = FuncyApiStatus.LOADING
-//            try {
-//                _works.value = repository.service.getWorks(token)
-//                _status.value = FuncyApiStatus.DONE
-//                Log.d(TAG, "通信出来たよ")
-//            } catch (e: Exception) {
-//                _status.value = FuncyApiStatus.ERROR
-//                _works.value = listOf()
-//                Log.e(TAG, e.message.toString())
-//            }
-//
-//        }
-//    }
+    private fun getWorks(token: String) {
+        viewModelScope.launch {
+            _status.value = FuncyApiStatus.LOADING
+            try {
+                _works.value = WorkRepository().getWork(token)
+                _status.value = FuncyApiStatus.DONE
+                Log.d(TAG, "通信出来たよ")
+            } catch (e: Exception) {
+                _status.value = FuncyApiStatus.ERROR
+                _works.value = listOf()
+                Log.e(TAG, e.message.toString())
+            }
+
+        }
+    }
 
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupViewModel.kt
@@ -62,14 +62,14 @@ class SignupViewModel : ViewModel() {
             try {
                 val res =userRepository.userRegistration(
                     SignupData(
+                        "noIcon",
                         familyName.value!!,
+                        firstName.value!!,
+                        sendMailAddress,
+                        password.value!!,
+                        grade,
                         course,
                         displayName.value!!,
-                        firstName.value!!,
-                        grade,
-                        "noIcon",
-                        sendMailAddress,
-                        password.value!!
                     )
                 )
                 if (res.isSuccessful) {

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/workDetail/WorkDetailFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/workDetail/WorkDetailFragment.kt
@@ -57,7 +57,7 @@ class WorkDetailFragment : Fragment() {
         })
 
         viewModel.images.observe(viewLifecycleOwner, Observer {
-            Glide.with(this).load(it[0].Image).error(R.drawable.img_work_detail_thumbnail).into(binding.imgThumbnail)
+            Glide.with(this).load(it[0].image).error(R.drawable.img_work_detail_thumbnail).into(binding.imgThumbnail)
         })
 
         viewModel.workDetailStatus.observe(viewLifecycleOwner, Observer { status ->

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/workDetail/WorkDetailViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/workDetail/WorkDetailViewModel.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.funcy_portfolio_android.model.data.ImageData
 import com.example.funcy_portfolio_android.model.data.TagData
-import com.example.funcy_portfolio_android.model.data.WorkData
+import com.example.funcy_portfolio_android.model.data.WorkDetails
 import com.example.funcy_portfolio_android.model.repository.WorkRepository
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
@@ -29,8 +29,8 @@ class WorkDetailViewModel : ViewModel() {
     val userName: LiveData<String> = _userName
 
     //ここから作品詳細
-    private val _work = MutableLiveData<WorkData>()
-    val work: LiveData<WorkData> = _work
+    private val _work = MutableLiveData<WorkDetails>()
+    val work: LiveData<WorkDetails> = _work
 
     private val _workDetailStatus = MutableLiveData<WorkApiStatus>()
     val workDetailStatus: LiveData<WorkApiStatus> = _workDetailStatus
@@ -79,7 +79,7 @@ class WorkDetailViewModel : ViewModel() {
         chipGroup.removeAllViews()
         _tagList.value?.forEach { tag ->
             val chip = Chip(context)
-            chip.text = tag.Tag
+            chip.text = tag.tag
             chipGroup.addView(chip)
         }
     }
@@ -91,7 +91,7 @@ class WorkDetailViewModel : ViewModel() {
         _explanation.value = workValue.description
         _tagList.value = workValue.tags
         _youtubeUrl.value = workValue.movie_url
-        _githubUrl.value = workValue.URL
+        _githubUrl.value = workValue.work_url
     }
 
     //Web遷移系の処理//////////////////////////////////

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.funcy_portfolio_android.model.data.ImageData
 import com.example.funcy_portfolio_android.model.data.TagData
-import com.example.funcy_portfolio_android.model.data.WorkData
+import com.example.funcy_portfolio_android.model.data.WorkDetails
 import com.example.funcy_portfolio_android.model.repository.WorkRepository
 import kotlinx.coroutines.launch
 
@@ -85,7 +85,7 @@ class WorkRegisterViewModel : ViewModel() {
         viewModelScope.launch {
             val postTagList = stringTagListToTagList(tags)
             res = workRepository.registerWork(
-                WorkData(
+                WorkDetails(
                     title,
                     description,
                     listOf(ImageData("")),

--- a/app/src/main/res/layout/create_card.xml
+++ b/app/src/main/res/layout/create_card.xml
@@ -3,43 +3,43 @@
 <layout>
 
     <data>
+
         <variable
             name="work"
-            type="com.example.funcy_portfolio_android.model.data.WorkDataList"/>
+            type="com.example.funcy_portfolio_android.model.data.WorkDataList" />
     </data>
 
-    <androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardCornerRadius="12dp"
-    app:cardElevation="6dp"
-    app:cardUseCompatPadding="true">
-
-    <LinearLayout
-        android:orientation="vertical"
+    <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="6dp"
+        app:cardUseCompatPadding="true">
 
-        <ImageView
-            android:id="@+id/image_view"
+        <LinearLayout
+            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="105dp"
-            android:scaleType="centerCrop"
-            app:imageUrl = "@{work.images}"/>
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/title_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textColor="@color/text_color"
-            android:background="@color/white"
-            android:autoSizeTextType="uniform"
-            android:paddingStart="5dp"
-            android:text="@{work.title}"/>
+            <ImageView
+                android:id="@+id/image_view"
+                android:layout_width="match_parent"
+                android:layout_height="105dp"
+                android:scaleType="centerCrop"
+                app:imageUrl="@{work.thumbnail}" />
 
-    </LinearLayout>
+            <TextView
+                android:id="@+id/title_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/text_color"
+                android:background="@color/white"
+                android:autoSizeTextType="uniform"
+                android:paddingStart="5dp"
+                android:text="@{work.title}" />
+
+        </LinearLayout>
     </androidx.cardview.widget.CardView>
 </layout>
 


### PR DESCRIPTION
## 対応するissue
- close #101 

## 概要
- データクラスの変数名をJSONのレスポンスのキーと統一しました．

## 意図する動作内容（または変更点）
#### 主な変更は以下です．細かい変更点はファイルを参照
- 既に定義されていたデータクラス（認証，サインアップ，作品一覧，作品詳細）の変数名を変更
- マイページデータクラスの追加
- 変数名の変更に伴い，各ファイルへの適用

## スクリーンショット（UI作成，変更時）
- 特になし

## その他
- JSONレスポンスは現時点（7月26日）で最新のサーバー（developブランチ）を使用しています