### PR TITLE
[compose] チップコンポーザブルの作成

### DIFF
--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/components/FuncyChip.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/components/FuncyChip.kt
@@ -1,4 +1,4 @@
-package com.example.funcy_portfolio_android.ui.composable
+package com.example.funcy_portfolio_android.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
@@ -13,15 +13,11 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.funcy_portfolio_android.ui.theme.FuncyColor
 
 
 /**
@@ -32,18 +28,18 @@ import androidx.compose.ui.unit.dp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchChip(
+    modifier: Modifier = Modifier,
     text: String,
     isSelected: Boolean,
-    modifier: Modifier = Modifier
+    onClick: () -> Unit,
 ) {
-    var isSelected by remember { mutableStateOf(isSelected) }
     val checkedChipColor = FilterChipDefaults.filterChipColors(
-        selectedContainerColor = Color(0xFFFFC2E2),
-        selectedLabelColor = Color(0xFF3b4043),
-        selectedLeadingIconColor = Color(0xFF3b4043)
+        selectedContainerColor = FuncyColor.primary,
+        selectedLabelColor = FuncyColor.text,
+        selectedLeadingIconColor = FuncyColor.text
     )
     FilterChip(
-        onClick = { isSelected = !isSelected },
+        onClick = { onClick() },
         selected = isSelected,
         label = { Text("#" + text, overflow = TextOverflow.Ellipsis) },
         leadingIcon = {
@@ -51,7 +47,7 @@ fun SearchChip(
                 Icon(
                     imageVector = Icons.Default.Done,
                     contentDescription = null,
-                    Modifier.size(InputChipDefaults.IconSize)
+                    modifier.size(InputChipDefaults.IconSize)
                 )
             }
         },
@@ -71,44 +67,35 @@ fun SearchChip(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SkillChip(
+    modifier: Modifier = Modifier,
     text: String,
     isEditable: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
 ) {
-    var editable by remember { mutableStateOf(isEditable) }
     val checkedChipColor = InputChipDefaults.inputChipColors(
-        selectedContainerColor = Color(0xFFFFFFFF)
+        selectedContainerColor = FuncyColor.white
     )
     val checkedChipBorder = InputChipDefaults.inputChipBorder(
-        selectedBorderColor = Color(0xFF3b4043),
+        selectedBorderColor = FuncyColor.text,
         selectedBorderWidth = 1.dp
     )
     InputChip(
         onClick = { onClick() },
-        selected = editable,
+        selected = isEditable,
         label = { Text("#" + text) },
         trailingIcon = {
-            if (editable) {
+            if (isEditable) {
                 Icon(
                     Icons.Default.Close,
                     contentDescription = null,
-                    Modifier.size(InputChipDefaults.AvatarSize)
+                    modifier.size(InputChipDefaults.AvatarSize)
                 )
             } else {
                 null
             }
         },
-        colors = if (editable) {
-            checkedChipColor
-        } else {
-            InputChipDefaults.inputChipColors()
-        },
-        border = if (editable) {
-            checkedChipBorder
-        } else {
-            InputChipDefaults.inputChipBorder()
-        }
+        colors = checkedChipColor,
+        border = checkedChipBorder
     )
 }
 
@@ -116,7 +103,7 @@ fun SkillChip(
 @Preview(showBackground = true)
 @Composable
 fun SearchChipPreview() {
-    SearchChip(text = "kotlin", isSelected = false)
+    SearchChip(text = "kotlin", isSelected = false, onClick = {})
 }
 
 

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/components/FuncyChip.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/components/FuncyChip.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -35,20 +35,21 @@ fun SearchChip(
 ) {
     val checkedChipColor = FilterChipDefaults.filterChipColors(
         selectedContainerColor = FuncyColor.primary,
-        selectedLabelColor = FuncyColor.text,
-        selectedLeadingIconColor = FuncyColor.text
+        selectedLabelColor = FuncyColor.white,
+        selectedLeadingIconColor = FuncyColor.white
     )
     FilterChip(
         onClick = { onClick() },
         selected = isSelected,
-        label = { Text("#" + text, overflow = TextOverflow.Ellipsis) },
-        leadingIcon = {
+        label = {
             if (isSelected) {
-                Icon(
-                    imageVector = Icons.Default.Done,
-                    contentDescription = null,
-                    modifier.size(InputChipDefaults.IconSize)
+                Text(
+                    "#" + text,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyMedium
                 )
+            } else {
+                Text("#" + text, overflow = TextOverflow.Ellipsis)
             }
         },
         colors = if (isSelected) {
@@ -103,7 +104,7 @@ fun SkillChip(
 @Preview(showBackground = true)
 @Composable
 fun SearchChipPreview() {
-    SearchChip(text = "kotlin", isSelected = false, onClick = {})
+    SearchChip(text = "kotlin", isSelected = true, onClick = {})
 }
 
 

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/composable/FuncyChip.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/composable/FuncyChip.kt
@@ -24,22 +24,30 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 
-// chipをタップすると，色が変化し，アイコンが出現する
+/**
+ * SearchChipはメイン画面のChipでタップすると色が変化し，チェックアイコンが出現する
+ * @param text Chipに表示されるテキスト内容
+ * @param isSelected Chipが選択されているかどうか状態を監視する
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchChip(content: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
-    var chekced by remember { mutableStateOf(false) }
+fun SearchChip(
+    text: String,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var isSelected by remember { mutableStateOf(isSelected) }
     val checkedChipColor = FilterChipDefaults.filterChipColors(
         selectedContainerColor = Color(0xFFFFC2E2),
         selectedLabelColor = Color(0xFF3b4043),
         selectedLeadingIconColor = Color(0xFF3b4043)
     )
     FilterChip(
-        onClick = { chekced = !chekced },
-        selected = chekced,
-        label = { Text(content, overflow = TextOverflow.Ellipsis) },
+        onClick = { isSelected = !isSelected },
+        selected = isSelected,
+        label = { Text("#" + text, overflow = TextOverflow.Ellipsis) },
         leadingIcon = {
-            if (chekced) {
+            if (isSelected) {
                 Icon(
                     imageVector = Icons.Default.Done,
                     contentDescription = null,
@@ -47,7 +55,7 @@ fun SearchChip(content: String, onClick: () -> Unit, modifier: Modifier = Modifi
                 )
             }
         },
-        colors = if (chekced) {
+        colors = if (isSelected) {
             checkedChipColor
         } else {
             FilterChipDefaults.filterChipColors()
@@ -55,19 +63,20 @@ fun SearchChip(content: String, onClick: () -> Unit, modifier: Modifier = Modifi
     )
 }
 
-
-// editStateはタグ編集判定のための変数
-// true -> ✕アイコンが出現
-// false -> 普通のchip
+/**
+ * SkillChipはマイページや作品投稿画面のChipで作成や編集が可能になっている
+ * @param text Chipに表示されるテキスト内容
+ * @param isEditable Chipが編集可能かどうかの状態を監視する
+ * */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SkillChip(
-    content: String,
+    text: String,
+    isEditable: Boolean,
     onClick: () -> Unit,
-    editState: Boolean,
     modifier: Modifier = Modifier
 ) {
-    var checked by remember { mutableStateOf(false) }
+    var editable by remember { mutableStateOf(isEditable) }
     val checkedChipColor = InputChipDefaults.inputChipColors(
         selectedContainerColor = Color(0xFFFFFFFF)
     )
@@ -76,11 +85,11 @@ fun SkillChip(
         selectedBorderWidth = 1.dp
     )
     InputChip(
-        onClick = { checked = !checked },
-        selected = checked,
-        label = { Text(content) },
+        onClick = { onClick() },
+        selected = editable,
+        label = { Text("#" + text) },
         trailingIcon = {
-            if (editState) {
+            if (editable) {
                 Icon(
                     Icons.Default.Close,
                     contentDescription = null,
@@ -90,12 +99,12 @@ fun SkillChip(
                 null
             }
         },
-        colors = if (checked) {
+        colors = if (editable) {
             checkedChipColor
         } else {
             InputChipDefaults.inputChipColors()
         },
-        border = if (checked) {
+        border = if (editable) {
             checkedChipBorder
         } else {
             InputChipDefaults.inputChipBorder()
@@ -107,7 +116,7 @@ fun SkillChip(
 @Preview(showBackground = true)
 @Composable
 fun SearchChipPreview() {
-    SearchChip(content = "#kotlin", onClick = {})
+    SearchChip(text = "kotlin", isSelected = false)
 }
 
 
@@ -115,7 +124,7 @@ fun SearchChipPreview() {
 @Composable
 fun SkillChipPreview() {
     Column {
-        SkillChip(content = "#kotlin", onClick = {}, editState = false)
-        SkillChip(content = "#kotlin", onClick = {}, editState = true)
+        SkillChip(text = "kotlin", onClick = {}, isEditable = false)
+        SkillChip(text = "kotlin", onClick = {}, isEditable = true)
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/composable/FuncyChip.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/composable/FuncyChip.kt
@@ -1,0 +1,121 @@
+package com.example.funcy_portfolio_android.ui.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+
+// chipをタップすると，色が変化し，アイコンが出現する
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchChip(content: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    var chekced by remember { mutableStateOf(false) }
+    val checkedChipColor = FilterChipDefaults.filterChipColors(
+        selectedContainerColor = Color(0xFFFFC2E2),
+        selectedLabelColor = Color(0xFF3b4043),
+        selectedLeadingIconColor = Color(0xFF3b4043)
+    )
+    FilterChip(
+        onClick = { chekced = !chekced },
+        selected = chekced,
+        label = { Text(content, overflow = TextOverflow.Ellipsis) },
+        leadingIcon = {
+            if (chekced) {
+                Icon(
+                    imageVector = Icons.Default.Done,
+                    contentDescription = null,
+                    Modifier.size(InputChipDefaults.IconSize)
+                )
+            }
+        },
+        colors = if (chekced) {
+            checkedChipColor
+        } else {
+            FilterChipDefaults.filterChipColors()
+        }
+    )
+}
+
+
+// editStateはタグ編集判定のための変数
+// true -> ✕アイコンが出現
+// false -> 普通のchip
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SkillChip(
+    content: String,
+    onClick: () -> Unit,
+    editState: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var checked by remember { mutableStateOf(false) }
+    val checkedChipColor = InputChipDefaults.inputChipColors(
+        selectedContainerColor = Color(0xFFFFFFFF)
+    )
+    val checkedChipBorder = InputChipDefaults.inputChipBorder(
+        selectedBorderColor = Color(0xFF3b4043),
+        selectedBorderWidth = 1.dp
+    )
+    InputChip(
+        onClick = { checked = !checked },
+        selected = checked,
+        label = { Text(content) },
+        trailingIcon = {
+            if (editState) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = null,
+                    Modifier.size(InputChipDefaults.AvatarSize)
+                )
+            } else {
+                null
+            }
+        },
+        colors = if (checked) {
+            checkedChipColor
+        } else {
+            InputChipDefaults.inputChipColors()
+        },
+        border = if (checked) {
+            checkedChipBorder
+        } else {
+            InputChipDefaults.inputChipBorder()
+        }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun SearchChipPreview() {
+    SearchChip(content = "#kotlin", onClick = {})
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun SkillChipPreview() {
+    Column {
+        SkillChip(content = "#kotlin", onClick = {}, editState = false)
+        SkillChip(content = "#kotlin", onClick = {}, editState = true)
+    }
+}


### PR DESCRIPTION
## 対応するissue
- close #110 

## 概要
- チップコンポーザブルの作成
- メイン画面にある検索のためのチップ（SearchChip）と マイページ等のスキルチップ（SkillChip）を作成
## 意図する動作内容（または変更点）
- SearchChipは押した後，Funcyのテーマカラーとチェックマークが出ることを確認
- SkillChipは普通のバージョンと削除バージョンの2つがある
　- 普通： 押しても変化がないことを確認
　- 削除：✕アイコンが出現することを確認

## スクリーンショット（UI作成，変更時）
![image](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/65755360/77422e01-5c68-4f67-b4ad-50accd044993)
![image](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/65755360/3d748a4d-d4df-4132-a3a2-abfd8474d1e0)

## その他
- 削除や文字数（最大30文字）の処理については未実装です。
- 文字数をComposable側で制御する場合は，実装が変化します。