### PR TITLE
[Fix] kaptからKSPへ移行した

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-kapt'
-
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -51,7 +50,7 @@ dependencies {
     implementation "androidx.browser:browser:1.4.0"
     implementation 'com.google.android:flexbox:1.1.0'
     implementation 'com.github.bumptech.glide:glide:4.4.0'
-    kapt 'com.github.bumptech.glide:compiler:4.4.0'
+    ksp 'com.github.bumptech.glide:compiler:4.4.0'
 
     // http通信
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
@@ -71,7 +70,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.13.0'
 
     implementation "com.squareup.moshi:moshi-kotlin:1.12.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.12.0"
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:1.12.0"
 
     //coil
     implementation "io.coil-kt:coil:1.1.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
     id 'com.google.devtools.ksp'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ buildscript {
     }
 }
 
+plugins{
+    id("com.google.devtools.ksp") version "1.6.10-1.0.2"
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## 対応するissue
- なし

## 概要
- kaptがメンテナンスモードなので推奨されているKSPに移行
    - kaptの使用箇所を削除して、KSPに置き換えた

    ※ DataBindingはKSPで対応していないのでkaptのままです。 

## 意図する動作内容（または変更点）
- ビルドができること

## スクリーンショット（UI作成，変更時）
<img src="" width="300" />

## その他