### PR TITLE
[Fix]compile-sdkを33にあげた

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 @Suppress("UnstableApiUsage")
 android {
-    compileSdk = 31
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.example.funcy_portfolio_android"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## 概要
- Compile SDKを31→33にあげた
    - Compose導入(#133 )のため

## 関連PR
1. CompileSDKを上げる　**← いまここ**
    - #135 
2. Compose導入とRecyclerViewの置き換え
    - #133 
3. データクラスの変更
    - #106 
4. 作品詳細画面の修正
    - #121 
    
## 意図する動作内容（または変更点）
- ビルドできること

## スクリーンショット（UI作成，変更時）
<img src="" width="300" />

## その他