### PR TITLE
signup, group registerにおいてアイコンをギャラリーから選択できるようにし、アイコンが円形になるように表示させた

### DIFF
--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/groupRegister/GroupRegisterFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/groupRegister/GroupRegisterFragment.kt
@@ -1,20 +1,24 @@
 package com.example.funcy_portfolio_android.ui.groupRegister
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentGroupRegisterBinding
 
 class GroupRegisterFragment : Fragment() {
-    private lateinit var binding : FragmentGroupRegisterBinding
+    private lateinit var binding: FragmentGroupRegisterBinding
+    private val REQUEST_GALLARY_TAKE = 2
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -33,41 +37,67 @@ class GroupRegisterFragment : Fragment() {
         }
 
         binding.etGroupName.setOnFocusChangeListener { _, hasFocus ->
-            if(!hasFocus)showoffKeyboard()
+            if (!hasFocus) showoffKeyboard()
         }
         binding.etGroupDiscription.setOnFocusChangeListener { _, hasFocus ->
-            if(!hasFocus)showoffKeyboard()
+            if (!hasFocus) showoffKeyboard()
         }
         binding.etGroupMailAddress.setOnFocusChangeListener { _, hasFocus ->
-            if(!hasFocus)showoffKeyboard()
+            if (!hasFocus) showoffKeyboard()
         }
 
         binding.etGroupName.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.etGroupMailAddress.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
+        }
+        binding.imageView.setOnClickListener {
+            openGallary()
         }
     }
-    private fun getActions(i:Int,keyEvent: KeyEvent?):Boolean{
-        if( i== EditorInfo.IME_ACTION_SEARCH||
-            i== EditorInfo.IME_ACTION_DONE||
-            keyEvent!=null&&
-            keyEvent.action == KeyEvent.ACTION_DOWN&&
-            keyEvent.keyCode== KeyEvent.KEYCODE_ENTER){
-            if(keyEvent==null||!keyEvent.isShiftPressed){
+
+    private fun getActions(i: Int, keyEvent: KeyEvent?): Boolean {
+        if (i == EditorInfo.IME_ACTION_SEARCH ||
+            i == EditorInfo.IME_ACTION_DONE ||
+            keyEvent != null &&
+            keyEvent.action == KeyEvent.ACTION_DOWN &&
+            keyEvent.keyCode == KeyEvent.KEYCODE_ENTER
+        ) {
+            if (keyEvent == null || !keyEvent.isShiftPressed) {
                 binding.root.requestFocus()
                 return true
-            }else{
+            } else {
                 return false
             }
-        }else{
+        } else {
             return false
         }
     }
 
-    private fun showoffKeyboard(){
-        val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    private fun showoffKeyboard() {
+        val imm =
+            requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(binding.root.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+    }
+
+    //ギャラリーを開く
+    private fun openGallary() {
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = "image/*"
+        startActivityForResult(intent, REQUEST_GALLARY_TAKE)
+    }
+
+    //ギャラリーで選択した画像を設定
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        when (requestCode) {
+            2 -> {
+                if (resultCode == Activity.RESULT_OK && requestCode == REQUEST_GALLARY_TAKE) {
+                    binding.imageView.setImageURI(data?.data)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/signup/SignupFragment.kt
@@ -1,8 +1,10 @@
 package com.example.funcy_portfolio_android.ui.signup
 
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -29,6 +31,7 @@ class SignupFragment : Fragment() {
 
     private lateinit var binding: FragmentSignupBinding
     private val viewModel by viewModels<SignupViewModel>()
+    private val REQUEST_GALLARY_TAKE = 2
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -103,6 +106,10 @@ class SignupFragment : Fragment() {
             )
         }
 
+        binding.imageAccount.setOnClickListener {
+            openGallery()
+        }
+
         viewModel.selectedItem.observe(viewLifecycleOwner, Observer {
             viewModel.setCourseId()
         })
@@ -114,7 +121,7 @@ class SignupFragment : Fragment() {
         viewModel.signupStatus.observe(viewLifecycleOwner, Observer { status ->
             val sharedPref = SharedPref(requireActivity())
 
-            when(status){
+            when (status) {
                 SignupViewModel.SignupApiStatus.LOADING -> {
                     binding.imageDone.visibility = View.GONE
                     binding.background.visibility = View.VISIBLE
@@ -123,7 +130,8 @@ class SignupFragment : Fragment() {
                 }
 
                 SignupViewModel.SignupApiStatus.SUCCESS -> {
-                    binding.textDialog.text = resources.getString(R.string.comp_registration_message)
+                    binding.textDialog.text =
+                        resources.getString(R.string.comp_registration_message)
                     binding.progressBar.visibility = View.GONE
                     binding.imageDone.visibility = View.VISIBLE
                     Handler(Looper.getMainLooper()).postDelayed(
@@ -131,10 +139,12 @@ class SignupFragment : Fragment() {
                             binding.background.visibility = View.GONE
                             binding.progressDialog.visibility = View.GONE
                             binding.buttonSignup.visibility = View.VISIBLE
-                            sharedPref.saveSharedPrefString(Keys.USERID.name, viewModel.userId.value.toString())
+                            sharedPref.saveSharedPrefString(
+                                Keys.USERID.name,
+                                viewModel.userId.value.toString()
+                            )
                             findNavController().navigate(R.id.action_SignupFragment_to_authenticationFragment)
-                        }
-                        ,2000
+                        }, 2000
                     )
                 }
 
@@ -144,10 +154,31 @@ class SignupFragment : Fragment() {
                     binding.buttonSignup.visibility = View.VISIBLE
                     Toast.makeText(context, "エラー", Toast.LENGTH_SHORT).show()
                 }
+
                 SignupViewModel.SignupApiStatus.INIT -> {}
                 else -> {}
             }
         })
+    }
+
+    //ギャラリーを開く
+    private fun openGallery() {
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = "image/*"
+        startActivityForResult(intent, REQUEST_GALLARY_TAKE)
+    }
+
+    //ギャラリーで選択した画像を設定
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        when (requestCode) {
+            2 -> {
+                if (resultCode == Activity.RESULT_OK && requestCode == REQUEST_GALLARY_TAKE) {
+                    binding.imageAccount.setImageURI(data?.data)
+                }
+            }
+        }
     }
 
     private fun setError(): Boolean {
@@ -208,66 +239,68 @@ class SignupFragment : Fragment() {
         //これを発動させるためにxmlの背景部分にあたるView(constraintlayoutなど)の
         //focusableとfocusableInTouchをtrueにセットする必要あり
         //↓もしフォーカスが外れたらキーボードを閉じる
-        binding.editDisplayName.setOnFocusChangeListener{ _,hasFocus->  //x
-            if(!hasFocus)showoffKeyboard()
+        binding.editDisplayName.setOnFocusChangeListener { _, hasFocus ->  //x
+            if (!hasFocus) showoffKeyboard()
         }
-        binding.editDisplayName.setOnFocusChangeListener{ _,hasFocus->
-            if(!hasFocus)showoffKeyboard()
+        binding.editDisplayName.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) showoffKeyboard()
         }
-        binding.editDisplayName.setOnFocusChangeListener{ _,hasFocus->
-            if(!hasFocus)showoffKeyboard()
+        binding.editDisplayName.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) showoffKeyboard()
         }
-        binding.editDisplayName.setOnFocusChangeListener{ _,hasFocus->
-            if(!hasFocus)showoffKeyboard()
+        binding.editDisplayName.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) showoffKeyboard()
         }
-        binding.editDisplayName.setOnFocusChangeListener{ _,hasFocus->
-            if(!hasFocus)showoffKeyboard()
+        binding.editDisplayName.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) showoffKeyboard()
         }
-        binding.editConfirmPassword.setOnFocusChangeListener{ _,hasFocus->
-            if(!hasFocus)showoffKeyboard()
+        binding.editConfirmPassword.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) showoffKeyboard()
         }
 
         //キー入力を検知してフォーカスを外す
         binding.editDisplayName.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.editDisplayName.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.editFirstName.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.editMailAddress.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.editPassword.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
         binding.editConfirmPassword.setOnEditorActionListener { _, i, keyEvent ->
-            return@setOnEditorActionListener getActions(i,keyEvent)
+            return@setOnEditorActionListener getActions(i, keyEvent)
         }
 
     }
 
-    private fun getActions(i:Int,keyEvent:KeyEvent?):Boolean{
-        if( i== EditorInfo.IME_ACTION_SEARCH||
-            i== EditorInfo.IME_ACTION_DONE||
-            keyEvent!=null&&
-            keyEvent.action == KeyEvent.ACTION_DOWN&&
-            keyEvent.keyCode== KeyEvent.KEYCODE_ENTER){
-            if(keyEvent==null||!keyEvent.isShiftPressed){
+    private fun getActions(i: Int, keyEvent: KeyEvent?): Boolean {
+        if (i == EditorInfo.IME_ACTION_SEARCH ||
+            i == EditorInfo.IME_ACTION_DONE ||
+            keyEvent != null &&
+            keyEvent.action == KeyEvent.ACTION_DOWN &&
+            keyEvent.keyCode == KeyEvent.KEYCODE_ENTER
+        ) {
+            if (keyEvent == null || !keyEvent.isShiftPressed) {
                 binding.root.requestFocus()
                 return true
-            }else{
+            } else {
                 return false
             }
-        }else{
+        } else {
             return false
         }
     }
 
-    private fun showoffKeyboard(){
-        val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    private fun showoffKeyboard() {
+        val imm =
+            requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(binding.root.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
     }
 }

--- a/app/src/main/res/layout/fragment_group_register.xml
+++ b/app/src/main/res/layout/fragment_group_register.xml
@@ -44,8 +44,7 @@
             android:layout_height="match_parent"
             android:focusable="true"
             android:focusableInTouchMode="true"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            >
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
             <!--    TODO:テキストの文字をstrings.xmlに追加    -->
 
             <TextView
@@ -66,7 +65,7 @@
                 android:layout_marginStart="24dp"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="24dp"
-                app:layout_constraintEnd_toStartOf="@+id/imageView"
+                app:layout_constraintEnd_toStartOf="@+id/icon"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tvGroupName">
 
@@ -74,7 +73,7 @@
                     android:id="@+id/etGroupName"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="text"/>
+                    android:inputType="text" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -149,7 +148,7 @@
                     android:id="@+id/etGroupMailAddress"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="text"/>
+                    android:inputType="text" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
@@ -174,17 +173,33 @@
 
 
             <!--     TODO:ナイトモードに合わせて色を変更できるようにする必要がある       -->
-            <ImageButton
-                android:id="@+id/imageView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="24dp"
-                android:src="@drawable/img_account"
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/icon"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_marginStart="230dp"
+                android:layout_marginTop="-20dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="-20dp"
+                android:background="#0000"
                 app:layout_constraintBottom_toBottomOf="@+id/otfGroupName"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/tvNecessary"
                 app:layout_constraintTop_toTopOf="@+id/tvGroupName"
-                app:tint="@color/black"
-                android:background="@null"/>
+                app:layout_constraintVertical_weight="1"
+                app:cardCornerRadius="32dp"
+                app:cardElevation="0dp">
+
+                <ImageButton
+                    android:id="@+id/imageView"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:background="@android:color/transparent"
+                    android:scaleType="centerCrop"
+                    app:srcCompat="@drawable/img_account"
+                    android:contentDescription="@null" />
+            </androidx.cardview.widget.CardView>
 
             <Button
                 android:id="@+id/btRegisterGroupWork"

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.example.funcy_portfolio_android.ui.signup.SignupViewModel" />
@@ -27,16 +28,18 @@
             android:id="@+id/scrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:descendantFocusability="beforeDescendants"
             android:focusable="true"
             android:focusableInTouchMode="true"
-            android:descendantFocusability="beforeDescendants">
+            tools:layout_editor_absoluteX="0dp"
+            tools:layout_editor_absoluteY="115dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginHorizontal="8dp"
-                android:focusableInTouchMode="true"
                 android:focusable="true"
+                android:focusableInTouchMode="true"
                 tools:context=".ui.signup.SignupFragment">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
@@ -68,12 +71,12 @@
                     android:layout_height="wrap_content"
                     android:gravity="center"
                     android:text="@string/registration_public_name"
-                    app:layout_constraintBottom_toBottomOf="@id/imageAccount"
+                    app:layout_constraintBottom_toBottomOf="@id/icon"
                     app:layout_constraintEnd_toStartOf="@+id/inputDisplayName"
                     app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintHorizontal_weight="1"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/imageAccount" />
+                    app:layout_constraintTop_toTopOf="@id/icon" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/inputDisplayName"
@@ -84,7 +87,7 @@
                     android:ems="10"
                     android:paddingVertical="4dp"
                     app:layout_constraintBottom_toBottomOf="@id/textDisplayName"
-                    app:layout_constraintEnd_toStartOf="@+id/imageAccount"
+                    app:layout_constraintEnd_toStartOf="@+id/icon"
                     app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintHorizontal_weight="3"
                     app:layout_constraintStart_toEndOf="@+id/textDisplayName"
@@ -94,22 +97,35 @@
                         android:id="@+id/editDisplayName"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@={viewModel.displayName}"
-                        android:inputType="text"/>
+                        android:inputType="text"
+                        android:text="@={viewModel.displayName}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
-                <ImageView
-                    android:id="@+id/imageAccount"
-                    android:layout_width="0dp"
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/icon"
+                    android:layout_width="64dp"
                     android:layout_height="64dp"
                     android:layout_marginTop="24dp"
+                    android:background="#0000"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintHorizontal_weight="1"
                     app:layout_constraintStart_toEndOf="@+id/inputDisplayName"
                     app:layout_constraintTop_toBottomOf="@+id/topConstraint"
-                    app:srcCompat="@drawable/img_account" />
+                    app:cardCornerRadius="32dp"
+                    app:cardElevation="0dp">
+
+                    <ImageButton
+                        android:id="@+id/imageAccount"
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:background="@android:color/transparent"
+                        android:scaleType="centerCrop"
+                        app:srcCompat="@drawable/img_account"
+                        android:contentDescription="@null" />
+                </androidx.cardview.widget.CardView>
+
 
                 <TextView
                     android:id="@+id/textFamilyName"
@@ -139,12 +155,12 @@
                     app:layout_constraintStart_toEndOf="@+id/textFamilyName"
                     app:layout_constraintTop_toBottomOf="@id/inputDisplayName">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editFamilyName"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="text"
-                android:text="@={viewModel.familyName}"/>
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editFamilyName"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:text="@={viewModel.familyName}" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## 対応するissue
- close #68 

## 概要
- ユーザ登録とグループ登録画面でのアイコンをギャラリーから設定できるようにし、円形に表示させるようにした

## 意図する動作内容（または変更点）
- ユーザ登録、グループ登録画面でアイコン画像の場所をタップすると、ギャラリーにアクセスし、そこで画像を選択するとアイコン画像としてそれが反映される
-↑の画面で表示される画像はスケールが調整され、円形に表示される
-

## スクリーンショット（UI作成，変更時）
<img src="" width="300" />
![Screenshot_2023-11-27-16-53-13-49](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/104344023/aad771a6-59c2-4842-894c-372552a36535)
![Screenshot_2023-11-27-16-53-50-80_02aa7fb97b79c031ca96fd56759b472e](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/104344023/97172467-1728-4cfe-91db-8000c6da6307)
![Screenshot_2023-11-27-16-53-39-66](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/104344023/5d92f5df-f4a8-465e-ba44-530fad7ec7df)
![Screenshot_2023-11-27-16-53-29-00_02aa7fb97b79c031ca96fd56759b472e](https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/104344023/b0724a16-d400-47fb-8c90-0fddcc34e123)

## その他