### PR TITLE
[feat]ログイン画面：入力情報の処理（メールアドレスの正規表現チェックなど）

### DIFF
--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/login/LoginFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.funcy_portfolio_android.R
@@ -32,7 +33,12 @@ class LoginFragment : Fragment() {
         }
 
         binding.btLogin.setOnClickListener {
-            findNavController().navigate(R.id.action_LoginFragment_to_MainFragment)
+            val mailAddress = binding.etMailAddress.text.toString()
+            if( mailAddress.matches(Regex("[a-zA-Z0-9._-]+@fun\\.ac\\.jp$"))) {
+                    findNavController().navigate(R.id.action_LoginFragment_to_MainFragment)
+            } else {
+                Toast.makeText(requireContext(), "メールアドレスが正しくありません", Toast.LENGTH_SHORT).show()
+            }
         }
         binding.btUserRegister.setOnClickListener {
             findNavController().navigate(R.id.action_LoginFragment_to_SignupFragment)

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -44,7 +44,7 @@
                 android:id="@+id/etMailAddress"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text" />
+                android:inputType="textEmailAddress" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -103,7 +103,7 @@
                 android:layout_marginStart="0dp"
                 android:layout_marginTop="0dp"
                 android:layout_marginEnd="0dp"
-                android:inputType="text" />
+                android:inputType="textPassword" />
 
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## 対応するissue
- close #63 

## 概要
- メールアドレスを未来大のメアドのみログインできるようにした
- パスワードを伏字に．

## 意図する動作内容（または変更点）
- メールアドレス押したら，英語のキーボード
- パスワード押したら，英語のキーボード
- パスワード入力したら，伏字
- メールアドレスが「~@fun.ac.jp」でない時にログインボタンを押したらログインできないようにした

## スクリーンショット（UI作成，変更時）
https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/38235279/815b76e6-54a5-4fe4-8017-4fa107ce27d4

## その他