### PR TITLE
[FIx] データクラスおよびリサイクラービューの修正

### DIFF
--- a/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkData.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/data/WorkData.kt
@@ -16,3 +16,7 @@ data class WorkData(
     val description: String,
     val icon: String,
 )
+
+fun WorkDataList.toWorkList():List<WorkData>{
+    return works
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/model/repository/WorkRepository.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/model/repository/WorkRepository.kt
@@ -1,6 +1,8 @@
 package com.example.funcy_portfolio_android.model.repository
 
+import com.example.funcy_portfolio_android.model.data.WorkData
 import com.example.funcy_portfolio_android.model.data.WorkDetails
+import com.example.funcy_portfolio_android.model.data.toWorkList
 import com.example.funcy_portfolio_android.network.ApiService
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
@@ -29,5 +31,5 @@ class WorkRepository() {
     suspend fun getWorkDetail(token: String, workId: String) =
         service.getWorkDetail(token = token, workId = workId)
 
-    suspend fun getWork(token: String) = service.getWorks(token = token)
+    suspend fun getWork(token: String):List<WorkData> = service.getWorks(token = token).toWorkList()
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/CardAdapterBefore.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/CardAdapterBefore.kt
@@ -7,9 +7,9 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.funcy_portfolio_android.R
-import com.example.funcy_portfolio_android.model.data.WorkDataList
+import com.example.funcy_portfolio_android.model.data.WorkData
 
-class CardAdapterBefore (private val worklist: List<WorkDataList>) : RecyclerView.Adapter<CardAdapterBefore.ViewHolder>(){
+class CardAdapterBefore (private val worklist: List<WorkData>) : RecyclerView.Adapter<CardAdapterBefore.ViewHolder>(){
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view){
         val image: ImageView = view.findViewById(R.id.image_view)
         val title: TextView = view.findViewById(R.id.title_text)
@@ -22,7 +22,7 @@ class CardAdapterBefore (private val worklist: List<WorkDataList>) : RecyclerVie
 
     override fun onBindViewHolder(viewHolder: CardAdapterBefore.ViewHolder, position: Int) {
         val work = worklist[position]
-        viewHolder.image.setImageResource(work.workID)
+        viewHolder.image.setImageResource((work.workID).toInt())
         viewHolder.title.text = work.title
     }
     override fun getItemCount() = worklist.size

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/GroupMypageFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/groupMypage/GroupMypageFragment.kt
@@ -6,11 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.example.funcy_portfolio_android.R
 import com.example.funcy_portfolio_android.databinding.FragmentGroupMypageBinding
-import com.example.funcy_portfolio_android.model.data.WorkDataList
 
 class GroupMypageFragment : Fragment() {
 
@@ -29,22 +26,22 @@ class GroupMypageFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val Worklist = listOf<WorkDataList>(
-            WorkDataList(R.drawable.garden_strand, "garden_strand", "ネックレス"),
-            WorkDataList(R.drawable.gatsby_hat, "gatsby_hat","ハット"),
-            WorkDataList(R.drawable.stella_sunglasses, "stella_sunglasses","グラス"),
-            WorkDataList(R.drawable.strut_earrings, "strut_earrings","イヤリング"),
-            WorkDataList(R.drawable.vagabond_sack, "vagabond_sack","リュックサック"),
-            WorkDataList(R.drawable.varsity_socks, "varsity_sovks","ソックス"),
-            WorkDataList(R.drawable.whitey_belt, "whitey_belt","ベルト"),
-            WorkDataList(R.drawable.copper_wire_rack, "whitey_belt","ラック"),
-            WorkDataList(R.drawable.gilt_desk_trio, "whitey_belt","小物入れ"),
-            WorkDataList(R.drawable.shrug_bag, "whitey_belt","バッグ")
-        )
+//        val Worklist = listOf<WorkDataList>(
+//            WorkDataList(R.drawable.garden_strand, "garden_strand", "ネックレス"),
+//            WorkDataList(R.drawable.gatsby_hat, "gatsby_hat","ハット"),
+//            WorkDataList(R.drawable.stella_sunglasses, "stella_sunglasses","グラス"),
+//            WorkDataList(R.drawable.strut_earrings, "strut_earrings","イヤリング"),
+//            WorkDataList(R.drawable.vagabond_sack, "vagabond_sack","リュックサック"),
+//            WorkDataList(R.drawable.varsity_socks, "varsity_sovks","ソックス"),
+//            WorkDataList(R.drawable.whitey_belt, "whitey_belt","ベルト"),
+//            WorkDataList(R.drawable.copper_wire_rack, "whitey_belt","ラック"),
+//            WorkDataList(R.drawable.gilt_desk_trio, "whitey_belt","小物入れ"),
+//            WorkDataList(R.drawable.shrug_bag, "whitey_belt","バッグ")
+//        )
 
-        val recyclerView = view.findViewById<RecyclerView>(R.id.rvGroupWorkList)
-
-        recyclerView.adapter = CardAdapterBefore(Worklist)
-        recyclerView.layoutManager = GridLayoutManager(context, 2, RecyclerView.VERTICAL, false)
+//        val recyclerView = view.findViewById<RecyclerView>(R.id.rvGroupWorkList)
+//
+//        recyclerView.adapter = CardAdapterBefore(Worklist)
+//        recyclerView.layoutManager = GridLayoutManager(context, 2, RecyclerView.VERTICAL, false)
     }
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/main/BindingAdapter.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/main/BindingAdapter.kt
@@ -5,10 +5,10 @@ import androidx.core.net.toUri
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
-import com.example.funcy_portfolio_android.model.data.WorkDataList
+import com.example.funcy_portfolio_android.model.data.WorkData
 
 @BindingAdapter("listData")
-fun bindRecyclerView(recyclerView: RecyclerView, data: List<WorkDataList>?){
+fun bindRecyclerView(recyclerView: RecyclerView, data: List<WorkData>?){
     val adapter = recyclerView.adapter as CardAdapter
     adapter.submitList(data)
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/main/CardAdapter.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/main/CardAdapter.kt
@@ -6,24 +6,24 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.funcy_portfolio_android.databinding.CreateCardBinding
-import com.example.funcy_portfolio_android.model.data.WorkDataList
+import com.example.funcy_portfolio_android.model.data.WorkData
 
-class CardAdapter : ListAdapter<WorkDataList, CardAdapter.WorkDataViewHolder>(DiffCallBack) {
+class CardAdapter : ListAdapter<WorkData, CardAdapter.WorkDataViewHolder>(DiffCallBack) {
 
     class WorkDataViewHolder(private var binding: CreateCardBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(workDataList: WorkDataList) {
-            binding.work = workDataList
+        fun bind(workData: WorkData) {
+            binding.work = workData
             binding.executePendingBindings()
         }
     }
 
-    companion object DiffCallBack : DiffUtil.ItemCallback<WorkDataList>() {
-        override fun areItemsTheSame(oldItem: WorkDataList, newItem: WorkDataList): Boolean {
+    companion object DiffCallBack : DiffUtil.ItemCallback<WorkData>() {
+        override fun areItemsTheSame(oldItem: WorkData, newItem: WorkData): Boolean {
             return oldItem.workID == newItem.workID
         }
 
-        override fun areContentsTheSame(oldItem: WorkDataList, newItem: WorkDataList): Boolean {
+        override fun areContentsTheSame(oldItem: WorkData, newItem: WorkData): Boolean {
             return oldItem.thumbnail == newItem.thumbnail
         }
 
@@ -43,34 +43,3 @@ class CardAdapter : ListAdapter<WorkDataList, CardAdapter.WorkDataViewHolder>(Di
         holder.bind(workData)
     }
 }
-
-
-//@BindingAdapter
-//fun bindArticle(article: ImageView, articleUrl: String?){
-//    articleUrl?.let{
-//        val articleUrl = articleUrl.toUri().buildUpon().scheme("https").build()
-//        article.load(articleUrl)
-//    }
-//}
-
-/*
-class CardAdapter(private val worklist: List<WorkData>) : RecyclerView.Adapter<CardAdapter.ViewHolder>(){
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view){
-        val image: ImageView = view.findViewById(R.id.image_view)
-        val maintitle: TextView = view.findViewById(R.id.title_text)
-        val subtitle: TextView = view.findViewById(R.id.name_text)
-    }
-
-    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
-        val layoutView = LayoutInflater.from(viewGroup.context).inflate(R.layout.create_card, viewGroup, false)
-        return ViewHolder(layoutView)
-    }
-
-    override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
-        val work = worklist[position]
-        viewHolder.image.setImageResource(work.image)
-        viewHolder.maintitle.text = work.main_title
-        viewHolder.subtitle.text = work.sub_title
-    }
-    override fun getItemCount() = worklist.size
-}*/

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/main/MainViewModel.kt
@@ -5,9 +5,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.funcy_portfolio_android.model.data.WorkDataList
+import com.example.funcy_portfolio_android.model.data.WorkData
 import com.example.funcy_portfolio_android.model.repository.WorkRepository
-import com.example.funcy_portfolio_android.ui.workRegister.WorkRegisterBottomSheet.Companion.TAG
 import kotlinx.coroutines.launch
 
 /*FUNCYサーバーとの接続を確認するステータスを定義*/
@@ -18,8 +17,8 @@ class MainViewModel : ViewModel() {
     private val workRepository = WorkRepository()
 
     //作品一覧を収納するデータホルダーを定義
-    private val _works = MutableLiveData<List<WorkDataList>>()
-    val works: LiveData<List<WorkDataList>> = _works
+    private val _works = MutableLiveData<List<WorkData>>()
+    val works: LiveData<List<WorkData>> = _works
 
     //Funcyサーバーとの接続状況を収納するホルダーを定義
     private val _status = MutableLiveData<FuncyApiStatus>()
@@ -33,9 +32,10 @@ class MainViewModel : ViewModel() {
         viewModelScope.launch {
             _status.value = FuncyApiStatus.LOADING
             try {
-                _works.value = WorkRepository().getWork(token)
+                _works.value = workRepository.getWork(token)
                 _status.value = FuncyApiStatus.DONE
                 Log.d(TAG, "通信出来たよ")
+                Log.d(TAG, _works.value.toString())
             } catch (e: Exception) {
                 _status.value = FuncyApiStatus.ERROR
                 _works.value = listOf()
@@ -43,6 +43,10 @@ class MainViewModel : ViewModel() {
             }
 
         }
+    }
+
+    companion object{
+        val TAG = "FuncyDebug"
     }
 
 }

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterFragment.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterFragment.kt
@@ -97,13 +97,13 @@ class WorkRegisterFragment : Fragment() {
                 AlertDialog.Builder(activity)
                     .setTitle("作品を投稿しますか？")
                     .setPositiveButton("登録する", DialogInterface.OnClickListener { dialog, which ->
-                        viewModel.registerWork(
-                            binding.etWorkTitle.text.toString(),
-                            binding.etWorkDescription.text.toString(),
-                            1,
-                            binding.etGitHubLink.text.toString(),
-                            binding.etYoutubeLink.text.toString()
-                        )
+//                        viewModel.registerWork(
+//                            binding.etWorkTitle.text.toString(),
+//                            binding.etWorkDescription.text.toString(),
+//                            1,
+//                            binding.etGitHubLink.text.toString(),
+//                            binding.etYoutubeLink.text.toString()
+//                        )
 
                         findNavController().navigate(R.id.action_WorkRegisterFragment_to_MainFragment)
 

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterViewModel.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/workRegister/WorkRegisterViewModel.kt
@@ -1,16 +1,11 @@
 package com.example.funcy_portfolio_android.ui.workRegister
 
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.example.funcy_portfolio_android.model.data.ImageData
 import com.example.funcy_portfolio_android.model.data.TagData
-import com.example.funcy_portfolio_android.model.data.WorkDetails
 import com.example.funcy_portfolio_android.model.repository.WorkRepository
-import kotlinx.coroutines.launch
 
 class WorkRegisterViewModel : ViewModel() {
 
@@ -75,32 +70,32 @@ class WorkRegisterViewModel : ViewModel() {
         return (tagFlag > 0)
     }
 
-    fun registerWork(
-        title: String,
-        description: String,
-        security: Int,
-        work_url: String,
-        youtube_url: String
-    ): String? {
-        viewModelScope.launch {
-            val postTagList = stringTagListToTagList(tags)
-            res = workRepository.registerWork(
-                WorkDetails(
-                    title,
-                    description,
-                    listOf(ImageData("")),
-                    work_url,
-                    youtube_url,
-                    postTagList,
-                    null,
-                    security
-                )
-            )
-            Log.e("res", res!!)
-        }
-
-        return res
-    }
+//    fun registerWork(
+//        title: String,
+//        description: String,
+//        security: Int,
+//        work_url: String,
+//        youtube_url: String
+//    ): String? {
+//        viewModelScope.launch {
+//            val postTagList = stringTagListToTagList(tags)
+//            res = workRepository.registerWork(
+//                WorkDetails(
+//                    title,
+//                    description,
+//                    listOf(ImageData("")),
+//                    work_url,
+//                    youtube_url,
+//                    postTagList,
+//                    null,
+//                    security
+//                )
+//            )
+//            Log.e("res", res!!)
+//        }
+//
+//        return res
+//    }
 
     //tagsのList<String>をList<TagData>に変換する(一応プライベートにしました)
     private fun stringTagListToTagList(stringList: List<String>): List<TagData> {

--- a/app/src/main/res/layout/create_card.xml
+++ b/app/src/main/res/layout/create_card.xml
@@ -6,7 +6,7 @@
 
         <variable
             name="work"
-            type="com.example.funcy_portfolio_android.model.data.WorkDataList" />
+            type="com.example.funcy_portfolio_android.model.data.WorkData" />
     </data>
 
     <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
## 対応するissue
- close #101

## 概要
- データクラスの変数名をJSONのレスポンスと一致するように修正
- データの受け渡しの処理を変更（下記にて詳細を記載）
- データクラスの変数名の変更に伴ってリサイクラービューおよび周辺の変数を変更

## 意図する動作内容（または変更点）
このプルリクでは以下の動作確認を実施しました．
- ローカル環境のサーバーに投稿された作品がメイン画面（作品一覧）で読み込みができていること

## スクリーンショット（UI作成，変更時）
画像が表示されている箇所とそうでない箇所があると思いますが
この部分についてはその他で詳細に記載しています．

<img src= "https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/65755360/d08edc1f-faaa-4988-aa73-78de03c4fdc4" width = "200">


## その他
#### データの受け渡し変更について
拡張関数の追加によってリポジトリ層で
WorkDataList -> WorkDataのListにレスポンスを変換することとした．
これによって，UIレイヤ（ViewやFragment）でのデータ変更を抑えることが可能

#### スクリーンショットで表示されている箇所とそうでない箇所の差について

- 表示されない原因
  - 調査中です...
  
- 現状わかっていること
  - 表示されている画像はインターネット上から読み込みが可能な画像 
（今回はこれを使用しました：[TheCatAPI](https://thecatapi.com/)）
  - 表示されていない画像は，ローカル環境のファイルサーバーにアップロードした画像
