### PR TITLE
compile-sdkを34に上げる

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 @Suppress("UnstableApiUsage")
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.funcy_portfolio_android"


### PR DESCRIPTION
## 対応するissue
- emoji2の1.4.0に対応するためにCompileSDKを34に上げる

## 概要
- 

## 意図する動作内容（または変更点）
- ビルドできること

## スクリーンショット（UI作成，変更時）
<img src="" width="300" />

## その他