### PR TITLE
[Compose] ボトムナビゲーションのコンポーザブルを実行

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,8 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
+    implementation("androidx.navigation:navigation-compose:2.5.3")
+    implementation("androidx.compose.material:material-icons-extended")
 
     // http通信
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/AppHost.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/AppHost.kt
@@ -1,0 +1,87 @@
+package com.example.funcy_portfolio_android.ui.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.funcy_portfolio_android.ui.AppNavHost
+import com.example.funcy_portfolio_android.ui.Destination
+import com.example.funcy_portfolio_android.ui.bottomScreens
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppHost(
+    modifier: Modifier = Modifier,
+    startDestination: String = Destination.MainScreen.route,
+) {
+    val navController = rememberNavController()
+
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            val backStackEntry by navController.currentBackStackEntryAsState()
+            val currentDestination = backStackEntry?.destination
+
+            val bottomScreenRoutes by lazy { bottomScreens.map { it.route }.toSet() }
+
+            if (currentDestination?.route in bottomScreenRoutes) {
+                NavigationBar(
+                    modifier = Modifier.height(70.dp)
+                ) {
+                    bottomScreens.forEach { screen ->
+                        val selected =
+                            currentDestination?.hierarchy?.any { it.route == screen.route } == true
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = {
+                                navController.navigate(screen.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                            icon = {
+                                if (selected) {
+                                    Icon(
+                                        imageVector = screen.selectedIcon,
+                                        contentDescription = null
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = screen.icon,
+                                        contentDescription = null
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            AppNavHost(
+                modifier = Modifier.padding(innerPadding),
+                navController = navController,
+                startDestination = startDestination,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/AppNavHost.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/AppNavHost.kt
@@ -1,0 +1,52 @@
+package com.example.funcy_portfolio_android.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+
+@Composable
+fun AppNavHost(
+    modifier: Modifier,
+    navController: NavHostController,
+    startDestination: String,
+){
+    NavHost(
+        modifier = modifier,
+        navController = navController,
+        startDestination = startDestination
+    ){
+        composable(route = Destination.MainScreen.route){
+            TestScreen(text = Destination.MainScreen.route)
+        }
+        composable(route = Destination.MypageScreen.route){
+            TestScreen(text = Destination.MypageScreen.route)
+        }
+        composable(route = Destination.GroupMypageScreen.route){
+            TestScreen(text = Destination.GroupMypageScreen.route)
+        }
+        composable(route = Destination.SettingScreen.route){
+            TestScreen(text = Destination.SettingScreen.route)
+        }
+    }
+}
+
+@Composable
+fun TestScreen(
+    modifier: Modifier = Modifier,
+    text: String,
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+        )
+    }
+}

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/Destination.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/Destination.kt
@@ -1,0 +1,50 @@
+package com.example.funcy_portfolio_android.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Build
+import androidx.compose.material.icons.outlined.Groups
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class Destination(
+    val route: String,
+    val selectedIcon: ImageVector = Icons.Filled.Build,
+    val icon: ImageVector = Icons.Outlined.Build,
+) {
+    object MainScreen : Destination(
+        route = "main_screen",
+        selectedIcon = Icons.Filled.Search,
+        icon = Icons.Outlined.Search,
+    )
+
+    object MypageScreen : Destination(
+        route = "mypage_screen",
+        selectedIcon = Icons.Filled.Person,
+        icon = Icons.Outlined.Person,
+    )
+
+    object GroupMypageScreen : Destination(
+        route = "gropu_mypage_screen",
+        selectedIcon = Icons.Filled.Groups,
+        icon = Icons.Outlined.Groups,
+    )
+    object SettingScreen : Destination(
+        route = "setting_screen",
+        selectedIcon = Icons.Filled.Settings,
+        icon = Icons.Outlined.Settings,
+    )
+}
+
+val bottomScreens = listOf(
+    Destination.MainScreen,
+    Destination.MypageScreen,
+    Destination.GroupMypageScreen,
+    Destination.SettingScreen,
+)

--- a/app/src/main/java/com/example/funcy_portfolio_android/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/funcy_portfolio_android/ui/MainActivity.kt
@@ -46,3 +46,18 @@ class MainActivity : AppCompatActivity() {
 //    }
 
 }
+
+
+/**
+ * MainActivity Composeの検証用
+ * 基本的にコメントに．composeの移行，テストの際のみ使用
+ */
+//class MainActivity : ComponentActivity() {
+//    override fun onCreate(savedInstanceState: Bundle?) {
+//        super.onCreate(savedInstanceState)
+//
+//        setContent {
+//            AppHost(startDestination = Destination.MainScreen.route)
+//        }
+//    }
+//}


### PR DESCRIPTION
## 対応するissue
- close #111 

## 概要
- ボトムナビゲーションのコンポーザブルを作成
- トップデスティネーションをMain, MyPage, Group, Settingとして作成し，ボトムによる遷移を実装
- MainActivityをComponentActivityのやつに書き換えてもらえばテストできます．
- TestScreenで遷移を表現（route：Stringを渡しています）

## 意図する動作内容（または変更点）
- ボトムで遷移できること
-
-

## スクリーンショット（UI作成，変更時）
<img src="https://github.com/Funcy-ICT/Funcy_Portfolio_Android/assets/60728861/961a7a22-8527-4ee6-8a33-1c0ce9a0146c" width="300" />


## その他